### PR TITLE
PMTiles format support

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,9 +11,9 @@
   <meta http-equiv="Content-Security-Policy" content="default-src 'self';
     style-src 'self' 'unsafe-inline' https://cdn.rawgit.com https://cdnjs.cloudflare.com https://fonts.googleapis.com;
     script-src 'self' https://cdn.rawgit.com https://cdnjs.cloudflare.com https://extreme-ip-lookup.com https://www.dropbox.com https://www.google-analytics.com https://maps.googleapis.com;
-    font-src https://fonts.gstatic.com https://fonts.googleapis.com;
+    font-src data: https://fonts.gstatic.com https://fonts.googleapis.com;
     connect-src *;
-    img-src * data:;
+    img-src * data: blob:;
     worker-src 'self';
     child-src 'none';
     object-src 'none'">
@@ -64,6 +64,8 @@
   <script src="js/pasteslib.js"></script>
   <!-- crypto functions -->
   <script src="js/encdec.js"></script>
+
+  <script src="js/pmtiles.js"></script>
 
   <script src="js/jscolor.min.js"></script>
   <script type="text/javascript" id="dropboxjs" data-app-key=""></script>

--- a/js/config.js
+++ b/js/config.js
@@ -393,6 +393,34 @@ var config = {
       },
       visible: false
     },
+    "IT Bugianen": {
+      type: "pmtiles",
+      url: "//maki.s3.fr-par.scw.cloud/Bugianen.pmtiles",
+      options: {
+        minZoom : 11,
+        maxZoom : 19,
+        minNativeZoom : 12,
+        maxNativeZoom : 16,
+        attribution : "&copy; CC BY-NC-SA 3.0 IT <a href='https://tartamillo.wordpress.com'>Maki</a>",
+      },
+      visible: false
+    },
+    "EU E.Slope Western-Alps": {
+      type: "pmtiles",
+      overlay: true,
+      url: "//maps.s3.fr-par.scw.cloud/eslo14_walps.pmtiles",
+      options: {
+        className: "blend-multiply",
+        opacity: 0.45,
+        minNativeZoom : 16,
+        maxNativeZoom : 16,
+        minZoom : 13,
+        maxZoom : 18,
+        attribution : "&copy; CC BY-NC-SA 3.0 <a href='https://github.com/eslopemap'>E.Slope</a>",
+      },
+      visible: false
+    },
+
     "Hills": {
       overlay: true,
       //'http://{s}.tiles.wmflabs.org/hillshading/{z}/{x}/{y}.png'

--- a/js/pmtiles.js
+++ b/js/pmtiles.js
@@ -24,7 +24,7 @@ const parseHeader = dataview => {
 }
 
 const bytesToMap = dataview => {
-    let m = new Map() 
+    let m = new Map()
     for (var i = 0; i < dataview.byteLength; i+=17) {
         var z_raw = dataview.getUint8(i,true)
         var z = z_raw & 127
@@ -38,7 +38,7 @@ const bytesToMap = dataview => {
     return m
 }
 
-export class PMTiles {
+class PMTiles {
     constructor(url) {
         this.url = url
         const controller = new AbortController()
@@ -60,6 +60,8 @@ export class PMTiles {
                 metadata: metadata,
                 dir:bytesToMap(new DataView(buf,10+header.json_size,17*header.root_entries))
             }
+        }).catch(error => {
+            console.error('Error fetching PMTile header:', error)
         })
 
         this.step = 0
@@ -128,10 +130,10 @@ export class PMTiles {
                             return null
                         })
                     }
-               } 
+               }
             }
             return null
-        }) 
+        })
     }
 
     // leaflet adapter
@@ -184,7 +186,7 @@ export class PMTiles {
     }
 }
 
-export const addProtocol = maplibre_instance => {
+const addProtocol = maplibre_instance => {
     let re = new RegExp(/pmtiles:\/\/(.+)\/(\d+)\/(\d+)\/(\d+)/)
     let pmtiles_instances = new Map()
     maplibregl.addProtocol('pmtiles', (params, callback) => {

--- a/js/pmtiles.js
+++ b/js/pmtiles.js
@@ -1,0 +1,220 @@
+// https://github.com/protomaps/PMTiles/blob/master/js/index.src.mjs
+
+const shift = (number, shift) => {
+    return number * Math.pow(2, shift)
+}
+
+const getUint24 = (dataview, pos) => {
+  return shift(dataview.getUint16(pos+1,true),8) + dataview.getUint8(pos,true)
+}
+
+const getUint48 = (dataview, pos) => {
+    return shift(dataview.getUint32(pos+2,true),16) + dataview.getUint16(pos,true)
+}
+
+const parseHeader = dataview => {
+    var magic = dataview.getUint16(0,true)
+    if (magic !== 19792) {
+      throw new Error('File header does not begin with "PM"')
+    }
+    var version = dataview.getUint16(2,true)
+    var json_size = dataview.getUint32(4,true)
+    var root_entries = dataview.getUint16(8,true)
+    return {version:version,json_size:json_size,root_entries:root_entries}
+}
+
+const bytesToMap = dataview => {
+    let m = new Map() 
+    for (var i = 0; i < dataview.byteLength; i+=17) {
+        var z_raw = dataview.getUint8(i,true)
+        var z = z_raw & 127
+        var is_dir = z_raw >> 7
+        var x = getUint24(dataview,i+1)
+        var y = getUint24(dataview,i+4)
+        var offset = getUint48(dataview,i+7)
+        var length = dataview.getUint32(i+13,true)
+        m.set(z + '_' + x + '_' + y,[offset,length,is_dir])
+    }
+    return m
+}
+
+export class PMTiles {
+    constructor(url) {
+        this.url = url
+        const controller = new AbortController()
+        const signal = controller.signal
+        this.root = fetch(this.url,{signal:signal, headers:{Range:'bytes=0-511999'}}).then(resp => {
+            if (resp.headers.get('Content-Length') != 512000) {
+                console.error("Content-Length mismatch indicates byte serving not supported; aborting.")
+                controller.abort()
+            }
+            return resp.arrayBuffer()
+        }).then(buf => {
+            let header = parseHeader(new DataView(buf,0,10))
+            let dec = new TextDecoder("utf-8")
+            let metadata = JSON.parse(dec.decode(new DataView(buf,10,header.json_size)))
+            if (metadata.compress) {
+                console.error(`Archive has compression type: ${metadata.compress} and is not readable directly by browsers.`)
+            }
+            return {
+                metadata: metadata,
+                dir:bytesToMap(new DataView(buf,10+header.json_size,17*header.root_entries))
+            }
+        })
+
+        this.step = 0
+        this.leaves = new Map()
+        this.outstanding_requests = new Map()
+    }
+
+    metadata = func => {
+        return new Promise((resolve,reject) => {
+            this.root.then(root => {
+                resolve(root.metadata)
+            })
+        })
+    }
+
+    getLeaf = (offset, len) => {
+        return new Promise((resolve,reject) => {
+            if (this.leaves.has(offset)) {
+                this.leaves.get(offset)[0]++
+                resolve(this.leaves.get(offset)[1])
+            } else if (this.outstanding_requests.has(offset)) {
+                this.outstanding_requests.get(offset).push(resolve)
+            } else {
+                this.outstanding_requests.set(offset,[])
+                fetch(this.url, {headers:{Range:'bytes=' + offset + '-' + (offset + len-1)}}).then(resp => {
+                    return resp.arrayBuffer()
+                }).then(buf => {
+                    var map = bytesToMap(new DataView(buf),len/17)
+                    if (this.leaves.size > 32) {
+                        var minStep = Infinity
+                        var minKey = undefined
+                        this.leaves.forEach((val,key) => {
+                            if (val[0] < minStep) {
+                                minStep = val[0]
+                                minKey = key
+                            }
+                        })
+                        this.leaves.delete(minKey)
+                    }
+
+                    this.leaves.set(offset,[this.step++,map])
+                    resolve(map)
+                    this.outstanding_requests.get(offset).forEach(f => f(map))
+                    this.outstanding_requests.delete(offset)
+                })
+            }
+        })
+    }
+
+    getZxy = (z,x,y) => {
+        var strid = z + '_' + x + '_' + y
+        return this.root.then(root => {
+            if (root.dir.has(strid) && root.dir.get(strid)[2] == 0) {
+                return root.dir.get(strid)
+            } else {
+               if (z >= 7) {
+                    var z7_tile_diff = (z - 7)
+                    var z7_tile = [7,Math.trunc(x / (1 << z7_tile_diff)), Math.trunc(y / (1 << z7_tile_diff))]
+                    var z7_tile_str = z7_tile[0] + "_" + z7_tile[1] + "_" + z7_tile[2]
+                    if (root.dir.has(z7_tile_str) && root.dir.get(z7_tile_str)[2] == 1) {
+                        const val = root.dir.get(z7_tile_str)
+                        return this.getLeaf(val[0],val[1]).then(leafdir => {
+                            if (leafdir.has(strid)) {
+                                return leafdir.get(strid)
+                            }
+                            return null
+                        })
+                    }
+               } 
+            }
+            return null
+        }) 
+    }
+
+    // leaflet adapter
+    leafletLayer = options => {
+        const self = this
+        var cls = L.GridLayer.extend({
+            createTile: function(coord, done){
+                var tile = document.createElement('img')
+
+                self.getZxy(coord.z,coord.x,coord.y).then(result => {
+                    if (result === null) return
+
+                    const controller = new AbortController()
+                    const signal = controller.signal
+                    tile.cancel = () => { controller.abort() }
+                    fetch(self.url,{signal:signal,headers:{Range:'bytes=' + result[0] + '-' + (result[0]+result[1]-1)}}).then(resp => {
+                        return resp.arrayBuffer()
+                    }).then(buf => {
+                        var blob = new Blob( [buf], { type: "image/png" } )
+                        var imageUrl = window.URL.createObjectURL(blob)
+                        tile.src = imageUrl
+                        tile.cancel = null
+                        done(null,tile)
+                    }).catch(error => {
+                        if (error.name !== "AbortError") throw error
+
+                    })
+                })
+                return tile
+            },
+
+            _removeTile: function (key) {
+                var tile = this._tiles[key]
+                if (!tile) { return }
+
+                if (tile.el.cancel) tile.el.cancel()
+
+                tile.el.width = 0
+                tile.el.height = 0
+                tile.el.deleted = true
+                L.DomUtil.remove(tile.el)
+                delete this._tiles[key]
+                this.fire('tileunload', {
+                    tile: tile.el,
+                    coords: this._keyToTileCoords(key)
+                })
+            },
+        })
+        return new cls(options)
+    }
+}
+
+export const addProtocol = maplibre_instance => {
+    let re = new RegExp(/pmtiles:\/\/(.+)\/(\d+)\/(\d+)\/(\d+)/)
+    let pmtiles_instances = new Map()
+    maplibregl.addProtocol('pmtiles', (params, callback) => {
+        let result = params.url.match(re)
+        let pmtiles_url = result[1]
+        if (!pmtiles_instances.has(pmtiles_url)) {
+            pmtiles_instances.set(pmtiles_url,new pmtiles.PMTiles(pmtiles_url))
+        }
+        let instance = pmtiles_instances.get(pmtiles_url)
+        let z = result[2]
+        let x = result[3]
+        let y = result[4]
+        var cancel = () => { }
+        instance.getZxy(+z,+x,+y).then(val => {
+            if (val) {
+                let headers = {'Range':'bytes=' + val[0] + '-' + (val[0]+val[1]-1)}
+                const controller = new AbortController()
+                const signal = controller.signal
+                cancel = () => { controller.abort() }
+                fetch(pmtiles_url,{signal:signal,headers:headers}).then(resp => {
+                    return resp.arrayBuffer()
+                }).then(arr => {
+                    callback(null,arr,null,null)
+                }).catch(e => {
+                    callback(new Error("Canceled"),null,null,null)
+                })
+            } else {
+                callback(null,new Uint8Array(),null,null)
+            }
+        })
+        return { cancel: () => { cancel() } }
+     })
+}

--- a/js/wtracks.js
+++ b/js/wtracks.js
@@ -2024,6 +2024,9 @@ $(function(){
       var mapopts = mapobj.options;
       if (isUnset(mapobj.type) || (mapobj.type === "base") || (mapobj.type === "overlay")) {
         tileCtor = L.tileLayer;
+      } else if (mapobj.type === "pmtiles") {
+        const pmTileCtor = new PMTiles(url,{allow_200:true})
+        p = pmTileCtor.leafletLayer(mapopts)
       } else {
         tileCtor = L.tileLayer[mapobj.type];
         if (mapobj.type === "wms" && mapopts.crs) {

--- a/maps.html
+++ b/maps.html
@@ -10,7 +10,7 @@
   <meta http-equiv="Content-Security-Policy" content="default-src 'self';
     style-src 'self' 'unsafe-inline' https://cdn.rawgit.com https://cdnjs.cloudflare.com https://fonts.googleapis.com;
     script-src 'self' https://cdn.rawgit.com https://cdnjs.cloudflare.com https://extreme-ip-lookup.com https://www.dropbox.com https://www.google-analytics.com https://maps.googleapis.com;
-    font-src https://fonts.gstatic.com https://fonts.googleapis.com;
+    font-src data: https://fonts.gstatic.com https://fonts.googleapis.com;
     connect-src *;
     img-src * data:;
     worker-src 'self';
@@ -131,6 +131,7 @@
               <label><input name="mymap-type" type="radio" value="base" checked="checked"/> Base</label>
               <label><input name="mymap-type" type="radio" value="wms"/> WMS</label>
               <label><input name="mymap-type" type="radio" value="wmts"/> WMTS</label>
+              <label><input name="mymap-type" type="radio" value="pmtiles"/> PMTiles</label>
             </td>
           </tr>
           <tr>


### PR DESCRIPTION
> [PMTiles](https://github.com/protomaps/PMTiles) is a single-file archive format for tiled data. A PMTiles archive can be hosted on a commodity storage platform such as S3, and enables low-cost, zero-maintenance map applications that are "serverless" - free of a custom tile backend or third party provider.

As such, I believe it fits well with WTracks serverless frontend :-)
I may also work on [COGeo](https://www.cogeo.org/) support in the future, but PMTiles is much lighter.

One issue with this simple integration is that a single HEAD request is made at each page load, because of [wtracks.js#L2042](https://github.com/opoto/wtracks/blob/master/js/wtracks.js#L2042) calling into [pmtiles.js#L48](https://github.com/eddy-geek/wtracks/blob/pmtiles/js/pmtiles.js#L48).

A current limitation is that PMTiles (or WMTS) can't be added as overlays. Do you see an issue with separating `type: "overlay"` into it own `overlay: true` field in the future?