### PR TITLE
Faster maps & tweaks

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -394,28 +394,30 @@ var config = {
       visible: false
     },
     "IT Bugianen": {
-      type: "pmtiles",
-      url: "//maki.s3.fr-par.scw.cloud/Bugianen.pmtiles",
+      // type: "pmtiles",
+      // url: "//maki.s3.fr-par.scw.cloud/Bugianen.pmtiles",
+      url: "//www.montagne.top/maki/Bugianen/{z}/{x}/{y}.jpg",
       options: {
         minZoom : 11,
-        maxZoom : 19,
+        maxZoom : 18,
         minNativeZoom : 12,
         maxNativeZoom : 16,
         attribution : "&copy; CC BY-NC-SA 3.0 IT <a href='https://tartamillo.wordpress.com'>Maki</a>",
       },
       visible: false
     },
-    "EU E.Slope Western-Alps": {
-      type: "pmtiles",
+    "EU eSlope Western-Alps": {
       overlay: true,
-      url: "//maps.s3.fr-par.scw.cloud/eslo14_walps.pmtiles",
+      // type: "pmtiles",
+      // url: "//maps.s3.fr-par.scw.cloud/AlpsWC_eslo.pmtiles",
+      url: "//www.montagne.top/tile/AlpsWC_eslo/{z}/{x}/{y}.png",
       options: {
         opacity: 0.45,
-        minNativeZoom : 16,
+        minNativeZoom : 13,
         maxNativeZoom : 16,
         minZoom : 13,
-        maxZoom : 18,
-        attribution : "&copy; CC BY-NC-SA 3.0 <a href='https://github.com/eslopemap'>E.Slope</a>",
+        maxZoom : 19,
+        attribution : "&copy; CC 1.0 <a href='https://github.com/eslopemap'>E.Slope</a>; &copy; <a href='https://geoservices.ign.fr/cgu-licences'>IGN</a>; &copy; <a href='http://www.datigeo-piem-download.it/direct/Geoportale/RegionePiemonte/Licenze/New/Licenza_CC40BY.pdf'>GeoPiemonte</a>; &copy; <a href='https://www.swisstopo.admin.ch/en/home/meta/conditions/geodata/ogd.html'>SwissTopo</a>",
       },
       visible: false
     },

--- a/js/wtracks.js
+++ b/js/wtracks.js
@@ -2027,6 +2027,15 @@ $(function(){
     if ((protocol.length == 0) || (protocol == "https:") || (location.protocol == "http:")) {
       var tileCtor;
       var mapopts = mapobj.options;
+      // By default, extend zoom range with down- & up-sampling
+      if (mapopts.minZoom && !mapopts.minNativeZoom) {
+        mapopts.minNativeZoom = mapopts.minZoom
+        mapopts.minZoom = mapopts.minZoom - 1
+      }
+      if (mapopts.maxZoom && !mapopts.maxNativeZoom) {
+        mapopts.maxNativeZoom = mapopts.maxZoom
+        mapopts.maxZoom = mapopts.maxZoom + 2
+      }
       if (isUnset(mapobj.type) || (mapobj.type === "base") || (mapobj.type === "overlay")) {
         tileCtor = L.tileLayer;
       } else if (mapobj.type === "pmtiles") {

--- a/maps.html
+++ b/maps.html
@@ -31,6 +31,7 @@
 </head>
 
 <body>
+  <a href="." class="btn-link link-home">&lt;&lt; Back to WTracks editor</a>
 
   <!-- Export Mymaps box -->
 


### PR DESCRIPTION
Sorry for the mix PR, I can remove or split out contentious stuff.

* Map config: Add *back* link on top
... as it can be hard to find with growing number of maps,
    and it's the expected location on mobile device
* By default, extend zoom range with down- & up-sampling
* Provide faster mirror for eSlope and Bugianen
Based on https://github.com/protomaps/go-pmtiles/
I left the pmtile file link commented, in case the proxy goes down because of SSL certif renewal or whatever.