### PR TITLE
New option 'autoGrayBaseLayer' 

### DIFF
--- a/css/wtracks.css
+++ b/css/wtracks.css
@@ -195,6 +195,9 @@ body {
 .blend-multiply {
   mix-blend-mode: multiply;
 }
+.filter-grayscale {
+  filter: grayscale(80%);
+}
 .overlay-opacity-slider {
   display: block;
   -webkit-appearance: none;

--- a/index.html
+++ b/index.html
@@ -457,7 +457,7 @@
           </p>
         </td>
       </tr>
-      <tr class="notopborder fold-settings trkstg">
+      <tr class="notopborder nobottomborder fold-settings trkstg">
         <td>
         </td>
         <td>
@@ -466,6 +466,18 @@
           <span id="extMarkershlp" class="help-b material-icons" title="Help">help_outline</span>
           <p id="extMarkershlp-help" class="help-p">
             When checked, a marker will be shown at start and end of current track segment.
+          </p>
+        </td>
+      </tr>
+      <tr class="notopborder fold-settings trkstg">
+        <td>
+        </td>
+        <td>
+          <input id="autoGrayBaseLayer" class="no-trim" type="checkbox" />
+          <label for="autoGrayBaseLayer">Grayscale base-layer map</label>
+          <span id="autoGrayBaseLayerhlp" class="help-b material-icons" title="Help">help_outline</span>
+          <p id="autoGrayBaseLayerhlp-help" class="help-p">
+            When checked and an overlay is enabled, base layer is displayed in gray. This is useful with slope overlays.
           </p>
         </td>
       </tr>

--- a/js/wtracks.js
+++ b/js/wtracks.js
@@ -121,6 +121,7 @@ $(function(){
   var fwdGuide = getBoolVal("wt.fwdGuide", config.display.fwdGuide);
   var fwdGuideGa = true; // collect stats on this user preference
   var extMarkers = getBoolVal("wt.extMarkers", config.display.extMarkers);
+  var autoGrayBaseLayer = getBoolVal("wt.autoGrayBaseLayer", config.display.autoGrayBaseLayer);
   var wasDragged;
 
   var EDIT_NONE = 0;
@@ -1098,6 +1099,7 @@ $(function(){
     setChecked("#fwdGuide", fwdGuide);
     setChecked("#wptLabel", wptLabel);
     setChecked("#extMarkers", extMarkers);
+    setChecked("#autoGrayBaseLayer", autoGrayBaseLayer);
     prepareTrim();
     $("#prunedist").val(prunedist);
     setChecked("#prunealt", prunealt);
@@ -1920,6 +1922,7 @@ $(function(){
     saveValOpt("wt.fwdGuide", fwdGuide);
     saveValOpt("wt.wptLabel", wptLabel);
     saveValOpt("wt.extMarkers", extMarkers);
+    saveValOpt("wt.autoGrayBaseLayer", autoGrayBaseLayer);
   }
 
   function saveStateFile() {
@@ -2125,6 +2128,7 @@ $(function(){
     if (mapsCloseOnClick) {
       $(".leaflet-control-layers").removeClass("leaflet-control-layers-expanded");
     }
+    setAutoGrayBaseLayer(e.layer);
   });
   map.on('zoomstart zoom zoomend', function(ev){
     debug('Zoom level: ' + map.getZoom());
@@ -2152,6 +2156,7 @@ $(function(){
   function setOverlay(name, yesno) {
     overlaysOn[name] = yesno;
     saveJsonValOpt("wt.overlaysOn", overlaysOn);
+    setAutoGrayBaseLayer(null)
   }
 
   /********* Overlay opacity control *************/
@@ -2214,6 +2219,28 @@ $(function(){
     setOverlay(e.name, false);
     removeOpacityControl(e.name);
   });
+
+  $("#autoGrayBaseLayer").change(function(evt){
+    autoGrayBaseLayer = !autoGrayBaseLayer;
+    storeVal("wt.autoGrayBaseLayer", autoGrayBaseLayer);
+    setAutoGrayBaseLayer(null);
+  });
+
+  function hasOverlaysOn() {
+    return Object.values(overlaysOn).some(oon => oon);
+  }
+  function setAutoGrayBaseLayer(layer) {
+    if (!layer) {
+      const layerId = L.Util.stamp(baseLayers[baseLayer]);
+      layer = map._layers[layerId];
+    }
+
+    if (autoGrayBaseLayer && hasOverlaysOn()) {
+      layer.getContainer().classList.add('filter-grayscale');
+    } else {
+      layer.getContainer().classList.remove('filter-grayscale');
+    }
+  }
 
   setLocation({lat: 0, lng: 0}); // required to initialize map
 


### PR DESCRIPTION
...for better readability when using slope overlays on top of colorful maps
> When checked and an overlay is enabled, base layer is displayed in gray

![image](https://user-images.githubusercontent.com/2772505/147393436-64f46d21-1074-4b4a-8927-0be766832ee8.png)
