### PR TITLE
Fix overlays restore (regression from #27)

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -79,7 +79,7 @@ function getParameterByName(name, defaultValue) {
   name = name.replace(/[\[]/, "\\[").replace(/[\]]/, "\\]");
   var regex = new RegExp("[\\?&]" + name + "=([^&#]*)"),
     results = regex.exec(location.search);
-  return results === null ? (isUnset(defaultValue) ? defaultValue : "") : decodeURIComponent(results[1].replace(/\+/g, " "));
+  return results === null ? defaultValue : decodeURIComponent(results[1].replace(/\+/g, " "));
 }
 
 function jsonClone(obj) {

--- a/js/wtracks.js
+++ b/js/wtracks.js
@@ -2064,10 +2064,10 @@ $(function(){
   var baseLayers = {};
   var overlays = {};
   var baseLayer = getVal("wt.baseLayer", config.display.map);
-  var requestedMap = getParameterByName("map")
-  var requestedOverlays = (getParameterByName("overlays") || "").split(',')
+  var requestedMap = getParameterByName("map");
+  var requestedOverlays = getParameterByName("overlays")?.split(',');
   mapsForEach(function(name, props) {
-    if (props.on ||  name == baseLayer || name === requestedMap || requestedOverlays.includes(name)) {
+    if (props.on ||  name == baseLayer || name === requestedMap || requestedOverlays?.includes(name)) {
       var inList = props.in == MAP_MY ? mymaps : config.maps;
       var tile = getProvider(inList[name]);
       if (tile) {


### PR DESCRIPTION
`"".split(',')` is `['']` which is truthy :cry: -- so we try to use overlay from URL instead of local-storage one.